### PR TITLE
feat: TAS-14 add get command to list all tasks

### DIFF
--- a/taskcli/cmd/get.go
+++ b/taskcli/cmd/get.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/MrShanks/Taska/common/logger"
+	"github.com/spf13/cobra"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "get all active tasks",
+	Long:  "get all active tasks store on the servere",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		var apiClient http.Client
+
+		response, err := apiClient.Get("http://localhost:8080/tasks")
+		if err != nil {
+			logger.ErrorLogger.Printf("Couldn't get a response from the server: %v", err)
+		}
+
+		bodyBytes, err := io.ReadAll(response.Body)
+		if err != nil {
+			logger.ErrorLogger.Printf("Couldn't read response body: %v", err)
+		}
+
+		fmt.Printf("%v\n", string(bodyBytes))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+}

--- a/taskcli/cmd/root.go
+++ b/taskcli/cmd/root.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var cfgFile string
@@ -40,8 +38,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
@@ -51,29 +47,4 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".Taska" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".Taska")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
-		fmt.Fprintln(os.Stderr, "couldn't find config file in ", viper.ConfigFileUsed())
-		os.Exit(1)
-	}
 }


### PR DESCRIPTION
get command lists all tasks available on the server it initialize a http client and issues get requests on the /tasks endpoint. When the next commands will be added we would need to mover the initialization of the api client someplace else.