### PR TITLE
feat: TAS-32 add export yaml and json functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ go.work.sum
 .env
 
 .idea
+
+export.json
+export.yaml

--- a/taskcli/cmd/get.go
+++ b/taskcli/cmd/get.go
@@ -2,11 +2,17 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"os"
 
+	"github.com/MrShanks/Taska/common/task"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var getCmd = &cobra.Command{
@@ -18,32 +24,89 @@ var getCmd = &cobra.Command{
 		ctx := context.Background()
 		apiClient := NewApiClient()
 
-		cmd.Printf("%s\n", FetchTasks(apiClient, ctx, "/tasks"))
+		format, err := cmd.Flags().GetString("export")
+		cobra.CheckErr(err)
+
+		data := FetchTasks(apiClient, ctx, "/tasks")
+
+		var bytes []byte
+
+		if isFlagSet(format) {
+			switch format {
+			case "yaml":
+				bytes, err = yaml.Marshal(data)
+				if err != nil {
+					log.Printf("error during yaml marshalling: %v", err)
+				}
+				dumpOnFile("export", format, bytes)
+			case "json":
+				bytes, err = json.MarshalIndent(data, "", "	")
+				if err != nil {
+					log.Printf("couldn't marshal indent: %v", err)
+				}
+				dumpOnFile("export", format, bytes)
+			default:
+				cmd.Printf("Unsupported file format: %s choose between json|yaml", format)
+			}
+			return
+		}
+
+		output, err := json.Marshal(data)
+		cobra.CheckErr(err)
+
+		cmd.Printf(fmt.Sprintf("%s\n", string(output)))
 	},
 }
 
-func FetchTasks(taskcli *Taskcli, ctx context.Context, endpoint string) string {
+func isFlagSet(flagValue string) bool {
+	return flagValue != ""
+}
+
+func dumpOnFile(filepath, format string, data []byte) {
+	file, err := os.Create(fmt.Sprintf("%s.%s", filepath, format))
+	if err != nil {
+		log.Printf("Couldn't create an export file: %v", err)
+	}
+
+	_, err = file.WriteString(fmt.Sprintf("%s\n", data))
+	if err != nil {
+		log.Printf("cannot write to %s, error: %v", file.Name(), err)
+	}
+
+	log.Printf("file created: %s.%s", "export", format)
+}
+
+func FetchTasks(taskcli *Taskcli, ctx context.Context, endpoint string) map[uuid.UUID]*task.Task {
 	taskcli.ServerURL.Path = endpoint
 
 	request, err := http.NewRequestWithContext(ctx, "GET", taskcli.ServerURL.String(), nil)
 	if err != nil {
-		return fmt.Sprintf("Couldn't create request: %v", err)
+		log.Printf("Couldn't create request: %v", err)
 	}
 
 	response, err := taskcli.HttpClient.Do(request)
 	if err != nil {
-		return fmt.Sprintf("Couldn't get a response from the server: %v", err)
+		log.Printf("Couldn't get a response from the server: %v", err)
 	}
 
-	bodyBytes, err := io.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
-		return fmt.Sprintf("Couldn't read response body: %v", err)
+		log.Printf("Couldn't read response body: %v", err)
 	}
 	defer response.Body.Close()
 
-	return fmt.Sprintf("%v", string(bodyBytes))
+	var tasks map[uuid.UUID]*task.Task
+
+	err = json.Unmarshal(data, &tasks)
+	if err != nil {
+		log.Printf("couldn't unmarshal: %v", err)
+	}
+
+	return tasks
 }
 
 func init() {
+	getCmd.Flags().StringP("export", "e", "", "export tasks in either json|yaml")
+
 	rootCmd.AddCommand(getCmd)
 }

--- a/taskcli/cmd/get.go
+++ b/taskcli/cmd/get.go
@@ -18,7 +18,7 @@ import (
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get all active tasks",
-	Long:  "Get all active tasks store on the server",
+	Long:  "Get or dump on a file all active tasks stored on the server",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()

--- a/taskcli/cmd/get_test.go
+++ b/taskcli/cmd/get_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/MrShanks/Taska/common/task"
@@ -21,7 +22,7 @@ func TestFetchTasks(t *testing.T) {
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte(jsonTask))
+			_, err := w.Write(jsonTask)
 			if err != nil {
 				t.Errorf("couldn't write the response")
 			}
@@ -39,11 +40,10 @@ func TestFetchTasks(t *testing.T) {
 		}
 
 		got := FetchTasks(mockClient, context.Background(), "/tasks")
-		want := string(jsonTask)
+		want := jsonTask
 
-		if got != want {
+		if reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
-
 	})
 }


### PR DESCRIPTION
```
make build && ./taskcli get --export yaml
```

```yaml
cat export.yaml | yq
3fe4ebac-2492-4c01-99d0-f2bfaa7414c2:
  id: 3fe4ebac-2492-4c01-99d0-f2bfaa7414c2
  title: first
  desc: Desc First
9b535e74-bb06-4b43-b75e-934b1887fabe:
  id: 9b535e74-bb06-4b43-b75e-934b1887fabe
  title: second
  desc: Desc Second
cee9d799-9dbb-4a4a-a61d-d8a47a524bfe:
  id: cee9d799-9dbb-4a4a-a61d-d8a47a524bfe
  title: third
  desc: Desc Third
```