### PR TITLE
refactor change map to slice return in task store

### DIFF
--- a/common/task/store.go
+++ b/common/task/store.go
@@ -3,7 +3,7 @@ package task
 import "github.com/google/uuid"
 
 type Store interface {
-	GetTasks() map[uuid.UUID]*Task
+	GetTasks() []*Task
 	GetOne(id string) (*Task, error)
 	New(*Task) uuid.UUID
 	Delete(id string) error

--- a/desktop/api.go
+++ b/desktop/api.go
@@ -66,7 +66,7 @@ func GetTasks(ctr *fyne.Container) {
 		fmt.Println("Error: ", err)
 	}
 
-	tasks := make(map[uuid.UUID]*task.Task)
+	tasks := []*task.Task{}
 	if err := json.Unmarshal(data, &tasks); err != nil {
 		fmt.Println("Error: ", err)
 	}

--- a/taskcli/cmd/common.go
+++ b/taskcli/cmd/common.go
@@ -92,9 +92,11 @@ func fetch(taskcli *Taskcli, ctx context.Context, endpoint string, result any) e
 		return fmt.Errorf("Couldn't get a response from the server: %v", err)
 	}
 	defer response.Body.Close()
+
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("task not found, status code: %v", response.StatusCode)
 	}
+
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return fmt.Errorf("Couldn't read response body: %v", err)

--- a/taskcli/cmd/get.go
+++ b/taskcli/cmd/get.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/MrShanks/Taska/common/task"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -74,8 +73,8 @@ func dumpOnFile(filepath, format string, data []byte) {
 	log.Printf("file created: %s.%s", "export", format)
 }
 
-func FetchTasks(taskcli *Taskcli, ctx context.Context, endpoint string) map[uuid.UUID]*task.Task {
-	tasks := make(map[uuid.UUID]*task.Task)
+func FetchTasks(taskcli *Taskcli, ctx context.Context, endpoint string) []*task.Task {
+	var tasks []*task.Task
 
 	err := fetch(taskcli, ctx, endpoint, &tasks)
 	if err != nil {

--- a/taskcli/cmd/get_test.go
+++ b/taskcli/cmd/get_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestFetch(t *testing.T) {
 	t.Run("Fetch Tasks returns all tasks in the store", func(t *testing.T) {
-		task1 := task.New("task1", "this is the task desc")
-		jsonTask, err := json.Marshal(task1)
+		tasks := []*task.Task{task.New("task1", "this is the task desc")}
+
+		jsonTask, err := json.Marshal(tasks)
 		if err != nil {
 			t.Errorf("couldn't Marshal task")
 		}

--- a/taskcli/cmd/getone.go
+++ b/taskcli/cmd/getone.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/MrShanks/Taska/common/task"
+	"github.com/spf13/cobra"
 	"io"
 	"log"
 	"net/http"
-
-	"github.com/MrShanks/Taska/common/task"
-	"github.com/google/uuid"
-	"github.com/spf13/cobra"
 )
 
 var getOneCmd = &cobra.Command{
@@ -59,7 +57,7 @@ func GetTaskUUIDs(taskcli *Taskcli, ctx context.Context, endpoint string) []stri
 	}
 	defer response.Body.Close()
 
-	var tasks map[uuid.UUID]*task.Task
+	var tasks []*task.Task
 	err = json.Unmarshal(bodyBytes, &tasks)
 	if err != nil {
 		log.Printf("Couldn't decode JSON: %v", err)

--- a/taskmgr/server/handler_test.go
+++ b/taskmgr/server/handler_test.go
@@ -140,6 +140,7 @@ func TestGeneralHandler(t *testing.T) {
 			}
 
 			response := httptest.NewRecorder()
+			defer response.Result().Body.Close()
 
 			test.handler(response, request)
 

--- a/taskmgr/server/handler_test.go
+++ b/taskmgr/server/handler_test.go
@@ -133,7 +133,6 @@ func TestGeneralHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			fmt.Println(test.desc, test.want, test.endpoint, test.handler)
 			request, err := http.NewRequestWithContext(context.Background(), "GET", test.endpoint, nil)
 			if err != nil {
 				t.Errorf("couldn't create request")

--- a/taskmgr/server/handler_test.go
+++ b/taskmgr/server/handler_test.go
@@ -36,15 +36,12 @@ func TestNewTaskHandler(t *testing.T) {
 
 	handler(response, request)
 
-	id := response.Body.String()
-	UUID := uuid.MustParse(id)
-
 	// "Check if the pushed task has been created": mockDatabase.GetTasks(),
 	got := mockDatabase.GetTasks()
 	want := task.New(newDummyTask.Title, newDummyTask.Desc)
 
-	if got[UUID].Title != want.Title {
-		t.Errorf("got: %v, want: %v", got[UUID].Title, want.Title)
+	if got[0].Title != want.Title {
+		t.Errorf("got: %v, want: %v", got[0].Title, want.Title)
 	}
 }
 

--- a/taskmgr/server/handler_test.go
+++ b/taskmgr/server/handler_test.go
@@ -133,7 +133,7 @@ func TestGeneralHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-
+			fmt.Println(test.desc, test.want, test.endpoint, test.handler)
 			request, err := http.NewRequestWithContext(context.Background(), "GET", test.endpoint, nil)
 			if err != nil {
 				t.Errorf("couldn't create request")
@@ -144,7 +144,7 @@ func TestGeneralHandler(t *testing.T) {
 
 			test.handler(response, request)
 
-			got := response.Result().StatusCode
+			got := response.Code
 
 			if got != test.want {
 				t.Errorf("got %v, want %v", got, test.want)

--- a/taskmgr/storage/db.go
+++ b/taskmgr/storage/db.go
@@ -20,10 +20,12 @@ func (db *PostgresDatabase) Connect(db_url string) error {
 	password := os.Getenv("POSTGRES_PWD")
 	dburl := fmt.Sprintf(db_url, password)
 	var err error
+
 	db.Conn, err = pgx.Connect(context.Background(), dburl)
 	if err != nil {
-		return err
+		return fmt.Errorf("error connecting to the database: %v", err)
 	}
+
 	return nil
 }
 
@@ -35,7 +37,7 @@ func (db *PostgresDatabase) GetOne(id string) (*task.Task, error) {
 	if row == pgx.ErrNoRows {
 		return nil, fmt.Errorf("task not found")
 	}
-	fmt.Printf("%v", t)
+
 	return &t, nil
 }
 
@@ -52,48 +54,58 @@ func (db *PostgresDatabase) GetTasks() []*task.Task {
 
 	for rows.Next() {
 		r := &task.Task{}
+
 		err := rows.Scan(&r.ID, &r.Title, &r.Desc)
 		if err != nil {
 			log.Printf("%v", err)
 		}
+
 		fetchedTasks = append(fetchedTasks, r)
 	}
 	return fetchedTasks
 }
 
 func (db *PostgresDatabase) New(task *task.Task) uuid.UUID {
-	task.ID = uuid.New()
-	query := fmt.Sprintf("insert into tasks (id, title, description) values ('%s', '%s', '%s');", task.ID, task.Title, task.Desc)
+	query := fmt.Sprintf("insert into tasks (title, description) values ('%s', '%s');", task.Title, task.Desc)
 
 	_, err := db.Conn.Exec(context.Background(), query)
 	if err != nil {
 		log.Printf("%v", err)
 		return uuid.Nil
 	}
+
 	return task.ID
 }
 
 func (db *PostgresDatabase) Update(id, title, desc string) (*task.Task, error) {
 	UUID, err := uuid.Parse(id)
-	var query string
 	if err != nil {
 		return nil, fmt.Errorf("invalid uuid: %s", id)
 	}
-	if title != "" {
-		query = fmt.Sprintf("update tasks set title = '%v' where id = '%s';", title, id)
-	}
 
-	if desc != "" {
-		query = fmt.Sprintf("update tasks set description = '%v' where id = '%s';", desc, id)
-	}
+	var query string
+
+	query = fmt.Sprintf(`update tasks set title = '%s', description = '%s' where id = '%s';`, title, desc, id)
 
 	update, err := db.Conn.Exec(context.Background(), query)
 	if err != nil {
-		return nil, fmt.Errorf("error updating task with ID %v with error %v", id, err)
-	} else if update.String() == "DELETE 0" {
+		return nil, fmt.Errorf("error updating task with ID %s with error %v", id, err)
+	}
+
+	if update.RowsAffected() == 0 {
 		return nil, fmt.Errorf("task with ID %v does not exist", UUID)
 	}
-	return &task.Task{ID: UUID}, nil
+
+	query = fmt.Sprintf("select * from tasks where id = '%s';", id)
+
+	var updatedTask task.Task
+
+	err = db.Conn.QueryRow(context.Background(), query).Scan(&updatedTask.ID, &updatedTask.Title, &updatedTask.Desc)
+	if err != nil {
+		return nil, fmt.Errorf("error updating task: %v", err)
+	}
+
+	return &updatedTask, nil
 }
 
 func (db *PostgresDatabase) Delete(id string) error {
@@ -101,14 +113,18 @@ func (db *PostgresDatabase) Delete(id string) error {
 	if err != nil {
 		return fmt.Errorf("invalid uuid: %s", id)
 	}
+
 	query := fmt.Sprintf("delete from tasks where id = '%s';", id)
 
 	del, err := db.Conn.Exec(context.Background(), query)
 	if err != nil {
 		return fmt.Errorf("error deleting task with ID %v with error %v", id, err)
-	} else if del.String() == "DELETE 0" {
+	}
+
+	if del.RowsAffected() == 0 {
 		return fmt.Errorf("task with ID %v does not exist", UUID)
 	}
+
 	log.Printf("Task with ID: %v has been deleted\n", UUID)
 	return nil
 }

--- a/taskmgr/storage/db.go
+++ b/taskmgr/storage/db.go
@@ -29,7 +29,6 @@ func (db *PostgresDatabase) Connect(db_url string) error {
 
 func (db *PostgresDatabase) GetOne(id string) (*task.Task, error) {
 	query := fmt.Sprintf("select * from tasks where id = '%s';", id)
-
 	t := task.Task{}
 
 	row := db.Conn.QueryRow(context.Background(), query).Scan(&t.ID, &t.Title, &t.Desc)
@@ -40,8 +39,8 @@ func (db *PostgresDatabase) GetOne(id string) (*task.Task, error) {
 	return &t, nil
 }
 
-func (db *PostgresDatabase) GetTasks() map[uuid.UUID]*task.Task {
-	fetchedTasks := make(map[uuid.UUID]*task.Task)
+func (db *PostgresDatabase) GetTasks() []*task.Task {
+	var fetchedTasks []*task.Task
 	query := "select * from tasks"
 
 	rows, err := db.Conn.Query(context.Background(), query)
@@ -52,16 +51,12 @@ func (db *PostgresDatabase) GetTasks() map[uuid.UUID]*task.Task {
 	defer rows.Close()
 
 	for rows.Next() {
-		var r task.Task
+		r := &task.Task{}
 		err := rows.Scan(&r.ID, &r.Title, &r.Desc)
 		if err != nil {
 			log.Printf("%v", err)
 		}
-		fetchedTasks[r.ID] = &task.Task{
-			ID:    r.ID,
-			Title: r.Title,
-			Desc:  r.Desc,
-		}
+		fetchedTasks = append(fetchedTasks, r)
 	}
 	return fetchedTasks
 }

--- a/taskmgr/storage/memory.go
+++ b/taskmgr/storage/memory.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/google/uuid"
 
@@ -34,6 +35,10 @@ func (imd *InMemoryDatabase) GetTasks() []*task.Task {
 	for _, val := range imd.Tasks {
 		tasks = append(tasks, val)
 	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].Title < tasks[j].Title
+	})
 
 	return tasks
 }

--- a/taskmgr/storage/memory.go
+++ b/taskmgr/storage/memory.go
@@ -28,8 +28,14 @@ func (imd *InMemoryDatabase) GetOne(id string) (*task.Task, error) {
 	return t, nil
 }
 
-func (imd *InMemoryDatabase) GetTasks() map[uuid.UUID]*task.Task {
-	return imd.Tasks
+func (imd *InMemoryDatabase) GetTasks() []*task.Task {
+	var tasks []*task.Task
+
+	for _, val := range imd.Tasks {
+		tasks = append(tasks, val)
+	}
+
+	return tasks
 }
 
 func (imd *InMemoryDatabase) New(task *task.Task) uuid.UUID {
@@ -47,6 +53,7 @@ func (imd *InMemoryDatabase) Update(id, title, desc string) (*task.Task, error) 
 	if _, ok := imd.Tasks[taskID]; !ok {
 		return nil, fmt.Errorf("task not found")
 	}
+
 	updateTask := imd.Tasks[uuid.MustParse(id)]
 
 	if title != "" {
@@ -65,6 +72,7 @@ func (imd *InMemoryDatabase) Delete(id string) error {
 	if err != nil {
 		return fmt.Errorf("invalid uuid: %s", id)
 	}
+
 	if _, ok := imd.Tasks[UUID]; !ok {
 		return fmt.Errorf("task with ID: %v not found", UUID)
 	}

--- a/taskmgr/storage/memory.go
+++ b/taskmgr/storage/memory.go
@@ -29,7 +29,7 @@ func (imd *InMemoryDatabase) GetOne(id string) (*task.Task, error) {
 }
 
 func (imd *InMemoryDatabase) GetTasks() []*task.Task {
-	var tasks []*task.Task
+	tasks := []*task.Task{}
 
 	for _, val := range imd.Tasks {
 		tasks = append(tasks, val)


### PR DESCRIPTION
it just makes so much more sense that the store returns a slice of tasks rather than a map. This PR will wait here until we merge the db and then we can rebase and fix that as well.