### PR TITLE
feat: TAS-63 add import tasks endpoint

### DIFF
--- a/common/task/store.go
+++ b/common/task/store.go
@@ -8,4 +8,5 @@ type Store interface {
 	New(*Task) uuid.UUID
 	Delete(id string) error
 	Update(id, title, desc string) (*Task, error)
+	BulkImport([]*Task)
 }

--- a/taskmgr/server/handler.go
+++ b/taskmgr/server/handler.go
@@ -188,7 +188,6 @@ func DeleteTaskHandler(store task.Store) http.HandlerFunc {
 
 func ImportTaskHandler(store task.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("error reading request body: %v", err)
@@ -199,6 +198,11 @@ func ImportTaskHandler(store task.Store) http.HandlerFunc {
 		var tasks []*task.Task
 
 		err = json.Unmarshal(body, &tasks)
+		if err != nil {
+			log.Printf("Couldn't unmarshal tasks into a slice of tasks: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 
 		store.BulkImport(tasks)
 

--- a/taskmgr/server/handler.go
+++ b/taskmgr/server/handler.go
@@ -186,6 +186,26 @@ func DeleteTaskHandler(store task.Store) http.HandlerFunc {
 	}
 }
 
+func ImportTaskHandler(store task.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("error reading request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var tasks []*task.Task
+
+		err = json.Unmarshal(body, &tasks)
+
+		store.BulkImport(tasks)
+
+		w.WriteHeader(http.StatusCreated)
+	}
+}
+
 func homeHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("Got request on / endpoint")
 

--- a/taskmgr/server/handler.go
+++ b/taskmgr/server/handler.go
@@ -188,6 +188,12 @@ func DeleteTaskHandler(store task.Store) http.HandlerFunc {
 
 func ImportTaskHandler(store task.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if err := isAllowedMethod(http.MethodPost, w, r); err != nil {
+			return
+		}
+
+		log.Printf("Got request on /import endpoint\n")
+
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("error reading request body: %v", err)

--- a/taskmgr/server/routes.go
+++ b/taskmgr/server/routes.go
@@ -15,6 +15,7 @@ func InitMuxWithRoutes(store task.Store) *http.ServeMux {
 	webMux.HandleFunc("/tasks", GetAllTasksHandler(store))
 	webMux.HandleFunc("/task/{task_id}", GetOneTaskHandler(store))
 	webMux.HandleFunc("/new", NewTaskHandler(store))
+	webMux.HandleFunc("/import", ImportTaskHandler(store))
 	webMux.HandleFunc("/delete/{task_id}", DeleteTaskHandler(store))
 	webMux.HandleFunc("/update/{task_id}", UpdateTaskHandler(store))
 

--- a/taskmgr/storage/db.go
+++ b/taskmgr/storage/db.go
@@ -128,3 +128,14 @@ func (db *PostgresDatabase) Delete(id string) error {
 	log.Printf("Task with ID: %v has been deleted\n", UUID)
 	return nil
 }
+
+func (db *PostgresDatabase) BulkImport(tasks []*task.Task) {
+	for _, t := range tasks {
+		query := fmt.Sprintf("insert into tasks (title, description) values ('%s', '%s');", t.Title, t.Desc)
+
+		_, err := db.Conn.Exec(context.Background(), query)
+		if err != nil {
+			log.Printf("%v", err)
+		}
+	}
+}

--- a/taskmgr/storage/memory.go
+++ b/taskmgr/storage/memory.go
@@ -86,3 +86,9 @@ func (imd *InMemoryDatabase) Delete(id string) error {
 	log.Printf("Task with ID: %v has been deleted", UUID)
 	return nil
 }
+
+func (imd *InMemoryDatabase) BulkImport(tasks []*task.Task) {
+	for _, task := range tasks {
+		imd.Tasks[task.ID] = task
+	}
+}


### PR DESCRIPTION
multiple tasks can be imported over the /import endpoint.

```bash
curl --location 'localhost:8080/import' \
--header 'Content-Type: application/json' \
--data '[
    {
        "title": "primo",
        "desc": "desc"
    },
    {
        "title": "second",
        "desc": "desc"
    }
]'
```