### PR TITLE
fix/new-error-handling

### DIFF
--- a/common/task/store.go
+++ b/common/task/store.go
@@ -5,7 +5,7 @@ import "github.com/google/uuid"
 type Store interface {
 	GetTasks(authorID string) []*Task
 	GetOne(id, authorID string) (*Task, error)
-	New(task *Task) uuid.UUID
+	New(task *Task) (uuid.UUID, error)
 	Delete(id, authorID string) error
 	Update(id, title, desc, authorID string) (*Task, error)
 	BulkImport(tasks []*Task, authorID string)

--- a/taskcli/cmd/new.go
+++ b/taskcli/cmd/new.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -69,7 +70,13 @@ func newTask(taskcli *Taskcli, ctx context.Context, endpoint, title, desc, token
 	}
 	defer response.Body.Close()
 
-	return fmt.Sprintf("%v", string(bodyBytes))
+	body := string(bodyBytes)
+
+	if strings.Contains(body, "duplicate key") {
+		return "Task title already exists"
+	}
+
+	return fmt.Sprintf("%v", body)
 }
 
 func init() {

--- a/taskmgr/server/handler.go
+++ b/taskmgr/server/handler.go
@@ -2,13 +2,11 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"log"
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
 	"gopkg.in/yaml.v3"
 
 	"github.com/MrShanks/Taska/common/author"
@@ -102,21 +100,10 @@ func NewTaskHandler(taskStore task.Store, authorStore author.Store) http.Handler
 
 		newTaskID, err := taskStore.New(&newTask)
 
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			log.Printf("Error, task with same name already exists")
-			w.WriteHeader(http.StatusInternalServerError)
-			_, err = w.Write([]byte("error, task with same name already exists"))
-			if err != nil {
-				log.Printf("Couldn't write response: %v", err)
-			}
-			return
-		}
-
 		if err != nil {
 			log.Printf("Could not insert new record into the database with error: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
-			_, err = w.Write([]byte("error inserting new task"))
+			_, err = w.Write([]byte(err.Error()))
 			if err != nil {
 				log.Printf("Couldn't write response: %v", err)
 			}

--- a/taskmgr/server/server.go
+++ b/taskmgr/server/server.go
@@ -86,7 +86,6 @@ func Listen(cfg *utils.Config) error {
 
 	ctxConnection, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-
 	conn, err := ConnectDB(ctxConnection, cfg.Spec.DB_URL)
 	if err != nil {
 		return err

--- a/taskmgr/storage/task_store_db.go
+++ b/taskmgr/storage/task_store_db.go
@@ -100,7 +100,6 @@ func (db *TaskStore) New(task *task.Task) (uuid.UUID, error) {
 	query = fmt.Sprintf("SELECT id FROM task WHERE title='%s'", task.Title)
 	row := db.Conn.QueryRow(ctx, query).Scan(&task.ID)
 	if row == pgx.ErrNoRows {
-		log.Printf("No task was found with ID: %v", err)
 		return uuid.Nil, err
 	}
 


### PR DESCRIPTION
I noticed that error handling in the new function was not entirely correct. Basically, if we were creating a task with the same name as an existing one, it was arising an error stating a task with that name already exists. However, even if there were any other types of error, such as special characters passed in the name, it was arising exactly the same error. I’ve implemented a way to differentiate these errors, but feel free to suggest a better approach if you have one
