### PR TITLE
feet/TAS-21-add-jwt-authentication

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,6 +69,7 @@ jobs:
           DBUSER: test
           DATABASE: testdb
           HOST: 127.0.0.1
+          TOKENSECRET: tokensecret
 
       - name: Test Signup 
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
           DBUSER: test
           DATABASE: testdb
           HOST: 127.0.0.1
-          TOKENSECRET: tokensecret
+          TOKENSECRET: test
 
       - name: Test Signup 
         run: |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.5
 
 require (
 	github.com/fatih/color v1.18.0
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/taskmgr/server/handler.go
+++ b/taskmgr/server/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MrShanks/Taska/common/author"
 	"github.com/MrShanks/Taska/common/task"
+	"github.com/MrShanks/Taska/utils"
 )
 
 const contentType = "Content-Type"
@@ -319,6 +320,14 @@ func Signin(authorStore author.Store) http.HandlerFunc {
 			return
 		}
 
+		token, err := utils.CreateToken(signInAuthor)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			log.Printf("Error creating token: %v", err)
+			return
+		}
+
+		// token := uuid.New().String()
 		loggedAuthors[token] = signInAuthor.Email
 
 		w.Header().Set("token", token)

--- a/taskmgr/server/middleware.go
+++ b/taskmgr/server/middleware.go
@@ -3,11 +3,13 @@ package server
 import (
 	"log"
 	"net/http"
+
+	"github.com/MrShanks/Taska/utils"
 )
 
 func LoggedInOnly(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := loggedAuthors[r.Header.Get("Token")]; !ok {
+		if utils.VerifyToken(LoggedAuthorToken) != nil {
 			log.Println("Unauthorized: Token not valid or empty")
 			w.WriteHeader(http.StatusUnauthorized)
 			if _, err := w.Write([]byte("You must login first")); err != nil {

--- a/taskmgr/server/middleware.go
+++ b/taskmgr/server/middleware.go
@@ -9,14 +9,20 @@ import (
 
 func LoggedInOnly(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if utils.VerifyToken(LoggedAuthorToken) != nil {
-			log.Println("Unauthorized: Token not valid or empty")
+		if LoggedAuthorToken == "" {
+			log.Println("Error: User not authenticated")
+			return
+		}
+		token, err := utils.VerifyToken(LoggedAuthorToken)
+		if err != nil {
+			log.Printf("Unauthorized: Token not valid or empty: %v\n", err)
 			w.WriteHeader(http.StatusUnauthorized)
 			if _, err := w.Write([]byte("You must login first")); err != nil {
 				log.Printf("couldn't write response")
 			}
 			return
 		}
+		log.Printf("Login accomplished with token: %v\n", token)
 
 		next(w, r)
 	}

--- a/taskmgr/server/server.go
+++ b/taskmgr/server/server.go
@@ -19,8 +19,6 @@ import (
 )
 
 var EventLogger logger.TransactionLogger
-
-// var LoggedAuthors = make(map[string]string)
 var LoggedAuthorToken string
 
 func initTransactionLog() error {

--- a/taskmgr/server/server.go
+++ b/taskmgr/server/server.go
@@ -19,7 +19,9 @@ import (
 )
 
 var EventLogger logger.TransactionLogger
-var loggedAuthors = make(map[string]string)
+
+// var LoggedAuthors = make(map[string]string)
+var LoggedAuthorToken string
 
 func initTransactionLog() error {
 	var err error

--- a/taskmgr/storage/author_store_db.go
+++ b/taskmgr/storage/author_store_db.go
@@ -81,5 +81,7 @@ func (db *AuthorStore) SignIn(email, password, token string) error {
 		return fmt.Errorf("couldn't save author token: %v", err)
 	}
 
+	// server.LoggedAuthorToken = token
+
 	return nil
 }

--- a/taskmgr/storage/author_store_db.go
+++ b/taskmgr/storage/author_store_db.go
@@ -80,8 +80,5 @@ func (db *AuthorStore) SignIn(email, password, token string) error {
 	if err != nil {
 		return fmt.Errorf("couldn't save author token: %v", err)
 	}
-
-	// server.LoggedAuthorToken = token
-
 	return nil
 }

--- a/utils/token.go
+++ b/utils/token.go
@@ -19,11 +19,13 @@ func CreateToken(author author.Author) (string, error) {
 			"sub": author.Email,
 			"iss": "taskmgr",
 			"iat": time.Now().Unix(),
-			"exp": time.Now().Add(time.Second * 30).Unix(),
+			"exp": time.Now().Add(time.Minute * 60).Unix(),
 		})
+
 	if secret == "" {
 		return "", fmt.Errorf("jwt secret not set")
 	}
+
 	singnedToken, err := token.SignedString([]byte(secret))
 	if err != nil {
 		return "", err
@@ -35,18 +37,16 @@ func VerifyToken(tokenString string) (*jwt.Token, error) {
 	if secret == "" {
 		return nil, fmt.Errorf("jwt secret not set")
 	}
+
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret), nil
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("error during token verification: %v", err)
 	}
-
 	if !token.Valid {
 		return nil, fmt.Errorf("invalid token")
 	}
-
 	return token, nil
 }
 

--- a/utils/token.go
+++ b/utils/token.go
@@ -16,7 +16,7 @@ var secret string = "secret"
 func CreateToken(author author.Author) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256,
 		jwt.MapClaims{
-			"sub": author.Firstname,
+			"sub": author.Email,
 			"iss": "taskmgr",
 			"iat": time.Now().Unix(),
 			"exp": time.Now().Add(time.Second * 30).Unix(),
@@ -32,7 +32,7 @@ func CreateToken(author author.Author) (string, error) {
 
 func VerifyToken(tokenString string) error {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		return []byte("secret-key"), nil
+		return []byte(secret), nil
 	})
 
 	if err != nil {

--- a/utils/token.go
+++ b/utils/token.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-var secret string = "secret"
+var secret string = os.Getenv("TOKENSECRET")
 
 func CreateToken(author author.Author) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256,
@@ -21,7 +21,9 @@ func CreateToken(author author.Author) (string, error) {
 			"iat": time.Now().Unix(),
 			"exp": time.Now().Add(time.Second * 30).Unix(),
 		})
-
+	if secret == "" {
+		return "", fmt.Errorf("jwt secret not set")
+	}
 	singnedToken, err := token.SignedString([]byte(secret))
 	if err != nil {
 		return "", err
@@ -30,6 +32,9 @@ func CreateToken(author author.Author) (string, error) {
 }
 
 func VerifyToken(tokenString string) (*jwt.Token, error) {
+	if secret == "" {
+		return nil, fmt.Errorf("jwt secret not set")
+	}
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret), nil
 	})

--- a/utils/token.go
+++ b/utils/token.go
@@ -26,24 +26,23 @@ func CreateToken(author author.Author) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(singnedToken)
 	return singnedToken, nil
 }
 
-func VerifyToken(tokenString string) error {
+func VerifyToken(tokenString string) (*jwt.Token, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret), nil
 	})
 
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("error during token verification: %v", err)
 	}
 
 	if !token.Valid {
-		return fmt.Errorf("invalid token")
+		return nil, fmt.Errorf("invalid token")
 	}
 
-	return nil
+	return token, nil
 }
 
 func ReadToken() string {

--- a/utils/token.go
+++ b/utils/token.go
@@ -5,7 +5,46 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/MrShanks/Taska/common/author"
+	"github.com/golang-jwt/jwt/v5"
 )
+
+var secret string = "secret"
+
+func CreateToken(author author.Author) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256,
+		jwt.MapClaims{
+			"sub": author.Firstname,
+			"iss": "taskmgr",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Second * 30).Unix(),
+		})
+
+	singnedToken, err := token.SignedString([]byte(secret))
+	if err != nil {
+		return "", err
+	}
+	fmt.Println(singnedToken)
+	return singnedToken, nil
+}
+
+func VerifyToken(tokenString string) error {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		return []byte("secret-key"), nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if !token.Valid {
+		return fmt.Errorf("invalid token")
+	}
+
+	return nil
+}
 
 func ReadToken() string {
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
First rough implementation of JWT token. For now, the expiration time is set to 30 seconds for testing purposes, but I’m considering setting it to 1 hour in the final version.

I've removed the global variable map since we now have a proper function that maps tokens to emails. However, I had to introduce another global variable as a reference for comparing the presented token attached to requests.

Even though we can query the database, we still need to store this token. For now, I thought it was better to use a global variable rather than query the database on every request. Might this be fully resolved once we introduce a proper caching mechanism?

Also, the secret is currently stored in plain text. Do you suggest exporting it as an environment variable, or do you have other ideas?